### PR TITLE
Features > Events link leads to 404 page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -109,7 +109,7 @@
                   {% endif %}
                 {% endfor %}
                 {% if cat.name == 'features' %}
-                <li><a href="/events/">Events</a></li>
+                <li><a href="/events">Events</a></li>
                 {% endif %}
               </ul>
             </details>


### PR DESCRIPTION
This seems to be caused by the extra trailing slash. This patch should fix it.