### PR TITLE
Add missing `path` parameter on the Server-Side docs

### DIFF
--- a/_docs/55_events/50_server-side.md
+++ b/_docs/55_events/50_server-side.md
@@ -46,6 +46,10 @@ Page view data uses the same endpoint, structured like this:
 
 To send test data, use the following cURL command:
 
+### Testing events
+
+Data should appear on your dashboard within minutes. You can always [export the raw latest data](/export-data) from our dashboard, or use the [Events Explorer](/events-explorer) to find your events.
+
 ```bash
 curl -X POST -H "Content-Type: application/json" -d '{
   "type": "event",
@@ -58,7 +62,16 @@ curl -X POST -H "Content-Type: application/json" -d '{
 }' https://queue.simpleanalyticscdn.com/events
 ```
 
-Data should appear on your dashboard within minutes. You can always [export the raw latest data](/export-data) from our dashboard, or use the [Events Explorer](/events-explorer) to find your events.
+### Testing page views
+
+```bashcurl -X POST -H "Content-Type: application/json" -d '{
+  "type": "pageview",
+  "hostname": "mobile-app.example.com",
+  "event": "pageview",
+  "path": "/my-page-name", 
+  "ua": "Your User Agent"
+}' https://queue.simpleanalyticscdn.com/events
+```
 
 ## Additional data fields
 

--- a/_docs/55_events/50_server-side.md
+++ b/_docs/55_events/50_server-side.md
@@ -37,6 +37,7 @@ Page view data uses the same endpoint, structured like this:
   "type": "pageview",
   "hostname": "example.com",
   "event": "pageview",
+  "path": "/page-name",
   "ua": "User Agent"
 }
 ```


### PR DESCRIPTION
[The code samples of how to log page views](https://docs.simpleanalytics.com/events/server-side#page-view-data-structure) on the Server-Side docs, seems to be incorrect.

When I run a curl with the pageview code example:

curl -X POST -H "Content-Type: application/json" -d '{
  "type": "pageview",
  "hostname": "mydomain.com",
  "event": "pageview",
  "ua": "App/1.30.1 (+https://www.mydomain.com/)"
}' https://queue.simpleanalyticscdn.com/events

I get the following error:

{"ok":false,"success":false,"message":"No (valid) 'path' specified","worker_id":19,"location":"not_set","duration_ms":1}%

which means that the sample code on the docs is incomplete.

what seems to be working is:

curl -X POST -H "Content-Type: application/json" -d '{
  "type": "pageview",
  "hostname": "mydomain.com",
  "event": "pageview",
  "path": "/my-page-name",  // <-- this part here is missing + very important
  "ua": "App/1.30.1 (+https://www.mydomain.com/)"
}' https://queue.simpleanalyticscdn.com/events.
